### PR TITLE
v1.2.1 Release

### DIFF
--- a/bulk-model-manager/plugin.cfg
+++ b/bulk-model-manager/plugin.cfg
@@ -1,7 +1,7 @@
 [plugin]
 
 name="Bulk Model Manager"
-description="Set external materials, export materials, and set up inherited scenes in bulk!"
+description="Set external materials, export materials and meshes, and set up inherited scenes in bulk!"
 author="Dragon1Freak"
-version="1.2.0"
+version="1.2.1"
 script="plugin.gd"


### PR DESCRIPTION
Use the ConfigFile server instead of FileAccess, this makes getting and setting the values on the .import file much easier and more reliable.

fixes #6 